### PR TITLE
174099259: do not use latest tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,7 @@ component-test:
 
 #Pushes the container to the docker registry/repository.
 publish: package
-	docker tag meetup/gauth-proxy:latest $(PUBLISH_TAG)
-	docker push $(PUBLISH_TAG)
-	docker push meetup/gauth-proxy:latest
+	@docker push $(PUBLISH_TAG)
 
 version:
 	@echo $(VERSION)


### PR DESCRIPTION
**Description**
Apparently the use of `latest` Docker tag is considered a bad practise and is not recommended: https://github.com/hadolint/hadolint/wiki/DL3007