### PR TITLE
fix: wrong cookie path

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -66,7 +66,7 @@ server {
       if type(cookies) ~= "table" then cookies = {cookies} end
       local newcookies = {}
       for i, val in ipairs(cookies) do
-        local newval = string.gsub(val, "([pP]ath)=/", "%1=/; SameSite=None")
+        local newval = val .. "; SameSite=None"
         table.insert(newcookies, newval)
       end
       ngx.header.set_cookie = newcookies


### PR DESCRIPTION
This is the Google Auth proxy which sits between you and the Admin Tool to make sure you are an employee with access to the Meetup Google Workspace.

This line of code wanted to force the `SameSite=None` policy to all the cookies served by the proxy, but it cause some bugs, as the `; SameSite=None` string was inserted inside `Path=/your-path` in a way that resulted in `Path=/; SameSite=Noneyour-path`.

This breaks the new auth cookies, as the refresh token is set the path `/gql2/refresh-token`, leading to sending the refresh token along with every request instead of refresh token ones only


I guess I will have to run `STAGE=preview make deploy-gauth-proxy` and `STAGE=prod make deploy-gauth-proxy` in `meetup/meetup/modules/admin` after merging